### PR TITLE
feat: criar home estática para casa de apostas esportiva

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -4,15 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GoleadaBet &mdash; Painel do jogador</title>
-    <link
-      rel="preconnect"
-      href="https://fonts.googleapis.com"
-    />
-    <link
-      rel="preconnect"
-      href="https://fonts.gstatic.com"
-      crossorigin
-    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap"
       rel="stylesheet"
@@ -30,7 +23,7 @@
           <input
             id="global-search"
             type="search"
-            placeholder="Buscar campeonatos, times ou mercados"
+            placeholder="Busque eventos, ligas ou times"
           />
         </form>
         <div class="header-widgets">
@@ -38,8 +31,8 @@
             <span class="balance-label">Saldo disponível</span>
             <strong class="balance-amount">R$ 1.275,00</strong>
           </div>
-          <button class="btn primary small">Depositar</button>
-          <button class="btn ghost small">Sacar</button>
+          <button class="btn primary small" type="button">Depositar</button>
+          <button class="btn ghost small" type="button">Sacar</button>
           <div class="user-chip">
             <span class="user-avatar" aria-hidden="true">LV</span>
             <div>
@@ -58,351 +51,500 @@
             <button class="category-button" type="button">Basquete</button>
             <button class="category-button" type="button">Tênis</button>
             <button class="category-button" type="button">Esports</button>
-            <button class="category-button" type="button">Boost de Odds</button>
             <button class="category-button" type="button">Promoções</button>
             <button class="category-button" type="button">Resultados</button>
           </nav>
           <div class="live-ticker" role="status">
-            <span class="ticker-label">Próximo destaque</span>
-            <span class="ticker-match">Libertadores: Fluminense x Boca Juniors em 18 min</span>
+            <span class="ticker-label">Começa em 12 min</span>
+            <span class="ticker-match">Champions: Real Madrid x Manchester City</span>
           </div>
         </div>
       </div>
     </header>
 
     <main class="dashboard-main">
-      <div class="container dashboard-grid">
-        <aside class="dashboard-sidebar" aria-label="Listas de esportes e campeonatos">
-          <section class="sidebar-card panel">
-            <header class="sidebar-card__header">
-              <h2>Favoritos</h2>
-              <button class="link-button" type="button">Gerenciar</button>
+      <div class="container dashboard-shell">
+        <aside class="shell-left" aria-label="Navegação por esportes">
+          <section class="panel side-panel">
+            <header>
+              <h2>Acesso rápido</h2>
             </header>
-            <ul class="sidebar-list">
+            <form class="side-search" role="search">
+              <label for="sidebar-search" class="sr-only">Buscar ligas ou equipes</label>
+              <span class="side-search__icon" aria-hidden="true">🔎</span>
+              <input
+                id="sidebar-search"
+                type="search"
+                placeholder="Buscar ligas ou equipes"
+              />
+            </form>
+            <div class="chip-group" aria-label="Filtros rápidos">
+              <button class="chip active" type="button">Ao vivo</button>
+              <button class="chip" type="button">Próximas 3h</button>
+              <button class="chip" type="button">Cashout</button>
+              <button class="chip" type="button">Boosts</button>
+              <button class="chip" type="button">Favoritos</button>
+            </div>
+            <ul class="favorite-list">
               <li>
-                <span>Brasileirão Série A</span>
-                <span class="sidebar-pill live">AO VIVO</span>
-              </li>
-              <li>
-                <span>Champions League</span>
-                <span class="sidebar-pill">+21</span>
-              </li>
-              <li>
-                <span>NBA</span>
-                <span class="sidebar-pill">Playoffs</span>
+                <span>Libertadores</span>
+                <span class="tag live">ao vivo</span>
               </li>
               <li>
                 <span>Premier League</span>
-                <span class="sidebar-pill">19:00</span>
+                <span class="tag soon">19h</span>
               </li>
               <li>
-                <span>Libertadores</span>
-                <span class="sidebar-pill">Hoje</span>
+                <span>NBA Playoffs</span>
+                <span class="tag soon">22h</span>
               </li>
             </ul>
           </section>
 
-          <section class="sidebar-card panel">
-            <header class="sidebar-card__header">
-              <h2>Campeonatos populares</h2>
-              <button class="link-button" type="button">Ver todos</button>
+          <section class="panel side-panel">
+            <header class="side-panel__header">
+              <h2>Esportes &amp; ligas</h2>
+              <button class="link-button" type="button">Gerenciar favoritos</button>
             </header>
-            <ul class="sidebar-list secondary">
-              <li>La Liga</li>
-              <li>Serie A Italiana</li>
-              <li>Copa do Nordeste</li>
-              <li>Liga dos Campeões da Ásia</li>
-              <li>CBLOL</li>
-              <li>ATP Masters 1000</li>
-            </ul>
-          </section>
+            <div class="sports-accordion">
+              <details class="accordion-item" open>
+                <summary>
+                  <div class="accordion-title">
+                    <span class="accordion-icon" aria-hidden="true">⚽</span>
+                    <span>Futebol</span>
+                  </div>
+                  <span class="accordion-badge">128</span>
+                </summary>
+                <ul>
+                  <li>
+                    <span>Brasileirão Série A</span>
+                    <span class="tag live">ao vivo 6</span>
+                  </li>
+                  <li>
+                    <span>Champions League</span>
+                    <span class="tag soon">21h</span>
+                  </li>
+                  <li>
+                    <span>Premier League</span>
+                    <span class="tag soon">amanhã</span>
+                  </li>
+                  <li>
+                    <span>La Liga</span>
+                    <span class="tag soon">+8</span>
+                  </li>
+                </ul>
+              </details>
 
-          <section class="sidebar-card panel">
-            <header class="sidebar-card__header">
-              <h2>Mercados rápidos</h2>
-            </header>
-            <div class="quick-markets">
-              <button class="quick-market" type="button">Ambos marcam</button>
-              <button class="quick-market" type="button">Handicap -1.5</button>
-              <button class="quick-market" type="button">Mais de 2.5 gols</button>
-              <button class="quick-market" type="button">Primeiro tempo</button>
-              <button class="quick-market" type="button">Cartões &gt; 4.5</button>
+              <details class="accordion-item" open>
+                <summary>
+                  <div class="accordion-title">
+                    <span class="accordion-icon" aria-hidden="true">🏀</span>
+                    <span>Basquete</span>
+                  </div>
+                  <span class="accordion-badge">52</span>
+                </summary>
+                <ul>
+                  <li>
+                    <span>NBA</span>
+                    <span class="tag live">ao vivo 2</span>
+                  </li>
+                  <li>
+                    <span>EuroLeague</span>
+                    <span class="tag soon">18h</span>
+                  </li>
+                  <li>
+                    <span>NBB</span>
+                    <span class="tag soon">+5</span>
+                  </li>
+                </ul>
+              </details>
+
+              <details class="accordion-item">
+                <summary>
+                  <div class="accordion-title">
+                    <span class="accordion-icon" aria-hidden="true">🎾</span>
+                    <span>Tênis</span>
+                  </div>
+                  <span class="accordion-badge">34</span>
+                </summary>
+                <ul>
+                  <li>
+                    <span>ATP Masters 1000</span>
+                    <span class="tag soon">quartas</span>
+                  </li>
+                  <li>
+                    <span>WTA Tour</span>
+                    <span class="tag soon">+9</span>
+                  </li>
+                </ul>
+              </details>
+
+              <details class="accordion-item">
+                <summary>
+                  <div class="accordion-title">
+                    <span class="accordion-icon" aria-hidden="true">🎮</span>
+                    <span>Esports</span>
+                  </div>
+                  <span class="accordion-badge">26</span>
+                </summary>
+                <ul>
+                  <li>
+                    <span>CBLOL</span>
+                    <span class="tag live">ao vivo</span>
+                  </li>
+                  <li>
+                    <span>Valorant Challengers</span>
+                    <span class="tag soon">17h</span>
+                  </li>
+                  <li>
+                    <span>CS:GO Pro League</span>
+                    <span class="tag soon">+3</span>
+                  </li>
+                </ul>
+              </details>
+
+              <details class="accordion-item">
+                <summary>
+                  <div class="accordion-title">
+                    <span class="accordion-icon" aria-hidden="true">🏐</span>
+                    <span>Vôlei</span>
+                  </div>
+                  <span class="accordion-badge">18</span>
+                </summary>
+                <ul>
+                  <li>
+                    <span>Superliga</span>
+                    <span class="tag soon">amanhã</span>
+                  </li>
+                  <li>
+                    <span>Liga das Nações</span>
+                    <span class="tag soon">+4</span>
+                  </li>
+                </ul>
+              </details>
             </div>
           </section>
         </aside>
 
-        <div class="dashboard-content">
-          <section class="featured-live panel" data-animate="fade-up">
-            <div class="featured-live__info">
-              <span class="pill pill-live">Libertadores &bull; Ao vivo</span>
-              <h1>Fluminense x Boca Juniors</h1>
-              <p>
-                Final eletrizante no Maracanã. O Tricolor pressiona buscando a virada
-                enquanto o Boca se fecha para segurar a vantagem mínima.
-              </p>
-              <div class="scoreboard">
-                <div class="scoreboard-team">
-                  <span class="team-name">Fluminense</span>
-                  <strong class="team-score">1</strong>
-                </div>
-                <div class="scoreboard-status">
-                  <span class="status-minute">72'</span>
-                  <span class="status-period">2º tempo</span>
-                </div>
-                <div class="scoreboard-team">
-                  <span class="team-name">Boca Juniors</span>
-                  <strong class="team-score">2</strong>
-                </div>
+        <div class="shell-center" role="region" aria-label="Conteúdo principal">
+          <section
+            class="panel hero-banner"
+            style="--hero-image: url('https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=1600&q=80');"
+          >
+            <span class="section-badge">Playoffs NBA • Ao vivo</span>
+            <h1>Boston Celtics x Miami Heat</h1>
+            <p>
+              Jogo 5 eletrizante no TD Garden. Os Celtics lideram por três pontos, mas o Miami
+              começa o último período com sequência de bolas de três. Aproveite o cashout inteligente
+              e as odds turbinadas.
+            </p>
+            <div class="hero-meta">
+              <span class="tag live">Q4 • 07:42</span>
+              <span>Transmissão disponível em HD</span>
+            </div>
+            <div class="hero-score">
+              <div class="hero-team">
+                <span>Boston Celtics</span>
+                <strong>102</strong>
               </div>
-              <div class="featured-actions">
-                <button class="btn primary">Adicionar ao bilhete</button>
-                <button class="btn ghost">Assistir transmissão</button>
+              <div class="hero-status">
+                <span>quarto período</span>
+                <span>tempo pedido</span>
+              </div>
+              <div class="hero-team hero-team--right">
+                <span>Miami Heat</span>
+                <strong>99</strong>
               </div>
             </div>
-            <div class="featured-live__markets">
-              <div class="market-block">
-                <span class="market-label">Resultado final</span>
-                <div class="market-options">
-                  <button class="odd-pill" type="button">1.92</button>
-                  <button class="odd-pill" type="button">3.25</button>
-                  <button class="odd-pill" type="button">4.10</button>
+            <div class="hero-markets">
+              <div class="hero-market">
+                <span class="hero-market__label">Resultado</span>
+                <div class="hero-market__odds">
+                  <button class="odd-chip" type="button">Celtics 1.65</button>
+                  <button class="odd-chip" type="button">Heat 2.45</button>
                 </div>
               </div>
-              <div class="market-block">
-                <span class="market-label">Próximo gol</span>
-                <div class="market-options">
-                  <button class="odd-pill" type="button">Fluminense 2.30</button>
-                  <button class="odd-pill" type="button">Boca 3.05</button>
-                  <button class="odd-pill" type="button">Sem gol 3.60</button>
+              <div class="hero-market">
+                <span class="hero-market__label">Total de pontos</span>
+                <div class="hero-market__odds">
+                  <button class="odd-chip" type="button">Mais de 212.5 • 1.90</button>
+                  <button class="odd-chip" type="button">Menos de 212.5 • 1.80</button>
                 </div>
               </div>
-              <div class="market-block">
-                <span class="market-label">Linha de gols</span>
-                <div class="market-options">
-                  <button class="odd-pill" type="button">Mais de 3.5 &mdash; 2.65</button>
-                  <button class="odd-pill" type="button">Menos de 3.5 &mdash; 1.48</button>
+              <div class="hero-market">
+                <span class="hero-market__label">Jogador destaque</span>
+                <div class="hero-market__odds">
+                  <button class="odd-chip" type="button">Tatum +30 pts • 2.80</button>
+                  <button class="odd-chip" type="button">Butler duplo-duplo • 3.10</button>
                 </div>
               </div>
+            </div>
+            <div class="hero-actions">
+              <button class="btn primary" type="button">Adicionar ao bilhete</button>
+              <button class="btn ghost" type="button">Ver estatísticas avançadas</button>
             </div>
           </section>
 
-          <section class="event-group panel" aria-labelledby="ao-vivo-agora">
-            <header class="group-header">
+          <section class="panel dashboard-section explosive-odds" data-animate="fade-up">
+            <header class="dashboard-section__header">
               <div>
-                <h2 id="ao-vivo-agora">Ao vivo agora</h2>
-                <p>Atualizado em tempo real com cashout inteligente.</p>
+                <h2>Odds explosivas</h2>
+                <p>Seleções com boosts exclusivos para multiplicar seus ganhos hoje.</p>
               </div>
-              <button class="link-button" type="button">Ver todos os eventos</button>
+              <button class="link-button" type="button">Ver todas as promoções</button>
             </header>
-            <div class="event-table" role="list">
-              <article class="event-row" role="listitem">
-                <div class="event-league">
-                  <span>Brasileirão Série A</span>
-                  <span class="event-minute">68'</span>
+            <div class="odds-grid">
+              <article class="odd-card" data-animate="fade-up">
+                <div class="odd-card__meta">
+                  <span>Libertadores</span>
+                  <span>Começa 21h</span>
                 </div>
-                <div class="event-teams">
-                  <span>Fortaleza</span>
-                  <span class="event-score">1 &ndash; 0</span>
-                  <span>Internacional</span>
+                <div class="odd-card__teams">
+                  <span>Fluminense</span>
+                  <span>vs</span>
+                  <span>Boca Juniors</span>
                 </div>
-                <div class="event-odds">
-                  <button class="odd-button" type="button">1.90</button>
-                  <button class="odd-button" type="button">3.45</button>
-                  <button class="odd-button" type="button">5.10</button>
+                <div class="odd-card__markets">
+                  <span class="odd-card__label">Resultado combinado</span>
+                  <div class="odd-card__odds">
+                    <button class="odd-chip" type="button">Flu vence + ambos marcam • 4.60</button>
+                    <button class="odd-chip" type="button">Boca + menos de 2.5 • 5.20</button>
+                  </div>
                 </div>
-                <div class="event-extra">
-                  <span>+124 mercados</span>
-                </div>
-              </article>
-              <article class="event-row" role="listitem">
-                <div class="event-league">
-                  <span>NBA &bull; Playoffs</span>
-                  <span class="event-minute">Q4 04:12</span>
-                </div>
-                <div class="event-teams">
-                  <span>Lakers</span>
-                  <span class="event-score">102 &ndash; 98</span>
-                  <span>Warriors</span>
-                </div>
-                <div class="event-odds">
-                  <button class="odd-button" type="button">1.65</button>
-                  <button class="odd-button" type="button">12.50</button>
-                  <button class="odd-button" type="button">2.45</button>
-                </div>
-                <div class="event-extra">
-                  <span>Cashout Rápido</span>
+                <div class="odd-card__footer">
+                  <span class="tag boost">boost +35%</span>
+                  <button class="btn primary small" type="button">Adicionar</button>
                 </div>
               </article>
-              <article class="event-row" role="listitem">
-                <div class="event-league">
+
+              <article class="odd-card" data-animate="fade-up">
+                <div class="odd-card__meta">
+                  <span>Premier League</span>
+                  <span>13 maio</span>
+                </div>
+                <div class="odd-card__teams">
+                  <span>Arsenal</span>
+                  <span>vs</span>
+                  <span>Manchester City</span>
+                </div>
+                <div class="odd-card__markets">
+                  <span class="odd-card__label">Mercados especiais</span>
+                  <div class="odd-card__odds">
+                    <button class="odd-chip" type="button">Arsenal +2 escanteios • 3.10</button>
+                    <button class="odd-chip" type="button">City vence virada • 8.20</button>
+                  </div>
+                </div>
+                <div class="odd-card__footer">
+                  <span class="tag boost">cashout turbo</span>
+                  <button class="btn ghost small" type="button">Detalhes</button>
+                </div>
+              </article>
+
+              <article class="odd-card" data-animate="fade-up">
+                <div class="odd-card__meta">
+                  <span>CBLOL</span>
+                  <span>Bo5 decisivo</span>
+                </div>
+                <div class="odd-card__teams">
+                  <span>LOUD</span>
+                  <span>vs</span>
+                  <span>paiN Gaming</span>
+                </div>
+                <div class="odd-card__markets">
+                  <span class="odd-card__label">Mapa vencedor</span>
+                  <div class="odd-card__odds">
+                    <button class="odd-chip" type="button">LOUD 3x1 • 3.90</button>
+                    <button class="odd-chip" type="button">paiN 3x2 • 5.60</button>
+                  </div>
+                </div>
+                <div class="odd-card__footer">
+                  <span class="tag boost">freebet 20%</span>
+                  <button class="btn primary small" type="button">Aproveitar</button>
+                </div>
+              </article>
+            </div>
+          </section>
+
+          <section class="panel dashboard-section live-now" data-animate="fade-up">
+            <header class="dashboard-section__header">
+              <div>
+                <h2>Ao vivo agora</h2>
+                <p>Acompanhe partidas com streaming e cashout instantâneo.</p>
+              </div>
+              <button class="link-button" type="button">Ver mais ao vivo</button>
+            </header>
+            <div class="live-strip">
+              <article class="live-card">
+                <div class="live-card__header">
+                  <span>Brasileirão</span>
+                  <span class="tag live">58'</span>
+                </div>
+                <div class="live-card__teams">
+                  <span>Palmeiras</span>
+                  <span>vs</span>
+                  <span>Grêmio</span>
+                </div>
+                <div class="live-card__score">
+                  <strong>2 x 1</strong>
+                  <span>Escanteios 6-3</span>
+                </div>
+                <div class="live-card__odds">
+                  <button class="odd-chip" type="button">Palmeiras 1.42</button>
+                  <button class="odd-chip" type="button">Grêmio 6.80</button>
+                  <button class="odd-chip" type="button">Próximo gol Verdão • 2.10</button>
+                </div>
+              </article>
+
+              <article class="live-card">
+                <div class="live-card__header">
+                  <span>Serie A</span>
+                  <span class="tag live">72'</span>
+                </div>
+                <div class="live-card__teams">
+                  <span>Inter de Milão</span>
+                  <span>vs</span>
+                  <span>Roma</span>
+                </div>
+                <div class="live-card__score">
+                  <strong>1 x 1</strong>
+                  <span>Finalizações 9-5</span>
+                </div>
+                <div class="live-card__odds">
+                  <button class="odd-chip" type="button">Inter 2.05</button>
+                  <button class="odd-chip" type="button">Roma 3.90</button>
+                  <button class="odd-chip" type="button">Empate 1.95</button>
+                </div>
+              </article>
+
+              <article class="live-card">
+                <div class="live-card__header">
                   <span>ATP Madrid</span>
-                  <span class="event-minute">Set 3</span>
+                  <span class="tag live">Set 3</span>
                 </div>
-                <div class="event-teams">
-                  <span>C. Alcaraz</span>
-                  <span class="event-score">6 &ndash; 4 &ndash; 5</span>
-                  <span>J. Sinner</span>
+                <div class="live-card__teams">
+                  <span>Alcaraz</span>
+                  <span>vs</span>
+                  <span>Rune</span>
                 </div>
-                <div class="event-odds">
-                  <button class="odd-button" type="button">1.55</button>
-                  <button class="odd-button" type="button">2.55</button>
+                <div class="live-card__score">
+                  <strong>6-7 / 6-4 / 3-2</strong>
+                  <span>Saques 7 aces</span>
                 </div>
-                <div class="event-extra">
-                  <span>Tiebreak ativo</span>
+                <div class="live-card__odds">
+                  <button class="odd-chip" type="button">Alcaraz 1.70</button>
+                  <button class="odd-chip" type="button">Rune 2.20</button>
                 </div>
               </article>
             </div>
-          </section>
-
-          <section class="event-group panel" aria-labelledby="boosts-dia">
-            <header class="group-header">
-              <div>
-                <h2 id="boosts-dia">Boosts do dia</h2>
-                <p>Odds turbinadas para slips selecionados.</p>
-              </div>
-              <button class="link-button" type="button">Termos</button>
-            </header>
-            <div class="boost-grid">
-              <article class="boost-card" data-animate="fade-up">
-                <span class="boost-label">+35%</span>
-                <h3>City vence + Haaland marca</h3>
-                <p>Odds aumentadas por tempo limitado para novos bilhetes simples.</p>
-                <div class="boost-odds">
-                  <span class="old-odds">2.10</span>
-                  <span class="new-odds">2.84</span>
-                </div>
-                <button class="btn primary small" type="button">Adicionar</button>
-              </article>
-              <article class="boost-card" data-animate="fade-up">
-                <span class="boost-label">+50%</span>
-                <h3>Real Madrid + Mais de 2.5</h3>
-                <p>Parlay exclusivo disponível até o início da partida.</p>
-                <div class="boost-odds">
-                  <span class="old-odds">3.40</span>
-                  <span class="new-odds">5.10</span>
-                </div>
-                <button class="btn primary small" type="button">Adicionar</button>
-              </article>
-              <article class="boost-card" data-animate="fade-up">
-                <span class="boost-label">+20%</span>
-                <h3>Vitória do Flamengo</h3>
-                <p>Válido para apostas simples até R$ 50 com cashout habilitado.</p>
-                <div class="boost-odds">
-                  <span class="old-odds">1.80</span>
-                  <span class="new-odds">2.16</span>
-                </div>
-                <button class="btn primary small" type="button">Adicionar</button>
-              </article>
-            </div>
-          </section>
-
-          <section class="event-group panel" aria-labelledby="agenda-dia">
-            <header class="group-header">
-              <div>
-                <h2 id="agenda-dia">Agenda do dia</h2>
-                <p>Não perca as partidas que você acompanha.</p>
-              </div>
-              <button class="link-button" type="button">Exportar</button>
-            </header>
-            <ul class="upcoming-list">
-              <li>
-                <div>
-                  <span class="upcoming-time">18:00</span>
-                  <strong>Palmeiras x São Paulo</strong>
-                  <span class="upcoming-league">Copa do Brasil &bull; Quartas</span>
-                </div>
-                <button class="odd-pill" type="button">Ver mercados</button>
-              </li>
-              <li>
-                <div>
-                  <span class="upcoming-time">19:30</span>
-                  <strong>Boston Celtics x Miami Heat</strong>
-                  <span class="upcoming-league">NBA &bull; Jogo 5</span>
-                </div>
-                <button class="odd-pill" type="button">Adicionar ao bilhete</button>
-              </li>
-              <li>
-                <div>
-                  <span class="upcoming-time">21:00</span>
-                  <strong>River Plate x Nacional</strong>
-                  <span class="upcoming-league">Libertadores &bull; Grupo D</span>
-                </div>
-                <button class="odd-pill" type="button">Pré-live</button>
-              </li>
-            </ul>
           </section>
         </div>
 
-        <aside class="dashboard-right" aria-label="Resumo da conta e bilhete">
-          <section class="betslip panel" aria-labelledby="bilhete-titulo">
-            <header class="betslip-header">
-              <h2 id="bilhete-titulo">Bilhete rápido</h2>
-              <span class="betslip-count">2 seleções</span>
+        <aside class="shell-right" aria-label="Bilhete e destaques">
+          <section class="panel betslip" aria-live="polite">
+            <header class="betslip__header">
+              <div>
+                <h2>Meu bilhete</h2>
+                <span class="betslip__label">3 seleções • Multiplicador 12.5x</span>
+              </div>
+              <div class="betslip__status">
+                <span class="tag boost">cashout on</span>
+                <button class="link-button" type="button">Limpar tudo</button>
+              </div>
             </header>
-            <div class="betslip-selections">
-              <article class="selection">
-                <div>
-                  <span class="selection-league">Brasileirão Série B</span>
-                  <strong class="selection-match">Sport x Ceará</strong>
-                  <span class="selection-market">Vitória do Sport</span>
+            <div class="betslip__list">
+              <article class="betslip-item">
+                <div class="betslip-item__head">
+                  <span class="tag live">ao vivo</span>
+                  <button class="betslip-remove" type="button" aria-label="Remover seleção">
+                    &times;
+                  </button>
                 </div>
-                <button class="remove-selection" type="button" aria-label="Remover seleção">&times;</button>
+                <h3>Fluminense x Boca Juniors</h3>
+                <p class="betslip-market">Resultado final &mdash; Boca Juniors</p>
+                <div class="betslip-odd">
+                  <span>Cota</span>
+                  <strong>3.25</strong>
+                </div>
               </article>
-              <article class="selection">
-                <div>
-                  <span class="selection-league">Premier League</span>
-                  <strong class="selection-match">Arsenal x Newcastle</strong>
-                  <span class="selection-market">Mais de 2.5 gols</span>
-                </div>
-                <button class="remove-selection" type="button" aria-label="Remover seleção">&times;</button>
-              </article>
-            </div>
-            <div class="betslip-stake">
-              <label for="stake" class="stake-label">Valor da aposta</label>
-              <div class="stake-control">
-                <button type="button" class="stake-adjust">-</button>
-                <input id="stake" type="number" value="50" min="10" step="10" />
-                <button type="button" class="stake-adjust">+</button>
-              </div>
-              <div class="stake-summary">
-                <div>
-                  <span>Retorno potencial</span>
-                  <strong>R$ 612,50</strong>
-                </div>
-                <div>
-                  <span>Cashout disponível</span>
-                  <strong>R$ 128,40</strong>
-                </div>
-              </div>
-              <button class="btn primary full" type="button">Confirmar aposta</button>
-            </div>
-          </section>
 
-          <section class="account panel">
-            <h2>Resumo da conta</h2>
-            <dl class="account-stats">
+              <article class="betslip-item">
+                <div class="betslip-item__head">
+                  <span class="tag">próximo jogo</span>
+                  <button class="betslip-remove" type="button" aria-label="Remover seleção">
+                    &times;
+                  </button>
+                </div>
+                <h3>Arsenal x Manchester City</h3>
+                <p class="betslip-market">Ambos marcam &mdash; Sim</p>
+                <div class="betslip-odd">
+                  <span>Cota</span>
+                  <strong>1.85</strong>
+                </div>
+              </article>
+
+              <article class="betslip-item">
+                <div class="betslip-item__head">
+                  <span class="tag">combo</span>
+                  <button class="betslip-remove" type="button" aria-label="Remover seleção">
+                    &times;
+                  </button>
+                </div>
+                <h3>LOUD x paiN Gaming</h3>
+                <p class="betslip-market">Total de mapas &mdash; Mais de 4.5</p>
+                <div class="betslip-odd">
+                  <span>Cota</span>
+                  <strong>2.75</strong>
+                </div>
+              </article>
+            </div>
+
+            <div class="betslip__stake">
+              <label for="stake-input" class="stake-label">Valor da aposta</label>
+              <div class="stake-control">
+                <button class="stake-adjust" type="button" aria-label="Diminuir valor">-</button>
+                <input id="stake-input" type="number" value="50" min="0" step="5" />
+                <button class="stake-adjust" type="button" aria-label="Aumentar valor">+</button>
+              </div>
+              <div class="betslip__quick" aria-label="Atalhos de valor">
+                <button class="quick-amount" type="button">R$ 20</button>
+                <button class="quick-amount" type="button">R$ 50</button>
+                <button class="quick-amount" type="button">R$ 100</button>
+                <button class="quick-amount" type="button">R$ 250</button>
+              </div>
+            </div>
+
+            <dl class="betslip__totals">
               <div>
-                <dt>Vencidas hoje</dt>
-                <dd>7</dd>
+                <dt>Retorno potencial</dt>
+                <dd>R$ 3.006,25</dd>
               </div>
               <div>
-                <dt>Apostas abertas</dt>
-                <dd>4</dd>
-              </div>
-              <div>
-                <dt>Cashout realizados</dt>
-                <dd>2</dd>
+                <dt>Lucro estimado</dt>
+                <dd>R$ 2.956,25</dd>
               </div>
             </dl>
-            <a class="link-button" href="#">Ver extrato completo</a>
+
+            <button class="btn primary full" type="button">Confirmar aposta</button>
+            <p class="betslip__disclaimer">Cashout disponível até os 70' do jogo de futebol.</p>
           </section>
 
-          <section class="support panel">
-            <h2>Suporte dedicado</h2>
-            <p>Estamos online 24 horas para tirar dúvidas e acompanhar suas apostas.</p>
+          <section class="panel highlight-card" data-animate="fade-up">
+            <span class="section-badge">Super boost do dia</span>
+            <h2>3 seleções ao vivo com +20% de lucro</h2>
+            <p>
+              Combine qualquer trio de partidas com streaming e receba um multiplicador adicional
+              automático.
+            </p>
+            <button class="btn ghost full" type="button">Ver regulamento</button>
+          </section>
+
+          <section class="panel support-card" data-animate="fade-up">
+            <h2>Central de suporte</h2>
+            <p>Equipe disponível 24h para tirar dúvidas sobre depósitos, apostas e verificação.</p>
             <div class="support-actions">
-              <button class="btn primary small" type="button">Abrir chat</button>
-              <button class="btn ghost small" type="button">Central de ajuda</button>
+              <button class="chip" type="button">Chat ao vivo</button>
+              <button class="chip" type="button">WhatsApp</button>
+              <button class="chip" type="button">Telegram</button>
             </div>
           </section>
         </aside>

--- a/dashboard.html
+++ b/dashboard.html
@@ -285,6 +285,128 @@
             </div>
           </section>
 
+          <section
+            class="panel rotating-banner"
+            data-carousel
+            data-animate="fade-up"
+            aria-label="Ofertas especiais em destaque"
+          >
+            <header class="rotating-banner__header">
+              <div class="rotating-banner__copy">
+                <span class="section-badge">Campanhas do momento</span>
+                <h2>Ofertas especiais para turbinar suas apostas</h2>
+                <p>
+                  Descubra boosts exclusivos, cashback em múltiplas e transmissões premiadas.
+                  Os banners alternam automaticamente e você também pode controlar manualmente.
+                </p>
+              </div>
+              <div class="rotating-banner__nav">
+                <button
+                  class="rotating-banner__arrow"
+                  type="button"
+                  data-carousel-prev
+                  aria-label="Banner anterior"
+                >
+                  <span aria-hidden="true">‹</span>
+                </button>
+                <button
+                  class="rotating-banner__arrow"
+                  type="button"
+                  data-carousel-next
+                  aria-label="Próximo banner"
+                >
+                  <span aria-hidden="true">›</span>
+                </button>
+              </div>
+            </header>
+
+            <div class="rotating-banner__viewport">
+              <article class="carousel__slide is-active" data-carousel-slide>
+                <img
+                  src="https://images.unsplash.com/photo-1517649763962-0c623066013b?auto=format&fit=crop&w=1600&q=80"
+                  alt="Torcedores vibrando em um estádio iluminado com fogos"
+                  loading="lazy"
+                />
+                <div class="carousel__content">
+                  <span class="carousel__badge">Freebet liberada</span>
+                  <h3>Combo Libertadores com bônus de 50%</h3>
+                  <p>
+                    Monte um bilhete com três jogos da fase de grupos e receba uma aposta grátis
+                    garantida para usar no ao vivo.
+                  </p>
+                  <div class="carousel__actions">
+                    <button class="btn primary small" type="button">Participar agora</button>
+                    <button class="btn ghost small" type="button">Ver regras</button>
+                  </div>
+                </div>
+              </article>
+
+              <article class="carousel__slide" data-carousel-slide>
+                <img
+                  src="https://images.unsplash.com/photo-1461896836934-ffe607ba8211?auto=format&fit=crop&w=1600&q=80"
+                  alt="Jogadores de futebol disputando bola com arquibancada lotada ao fundo"
+                  loading="lazy"
+                />
+                <div class="carousel__content">
+                  <span class="carousel__badge">Cashback 20%</span>
+                  <h3>Proteção total na rodada da Premier League</h3>
+                  <p>
+                    Aposte nos mercados especiais de artilheiros e, se perder por um gol,
+                    devolvemos parte do valor em crédito.
+                  </p>
+                  <div class="carousel__actions">
+                    <button class="btn primary small" type="button">Garantir cashback</button>
+                    <button class="btn ghost small" type="button">Explorar mercados</button>
+                  </div>
+                </div>
+              </article>
+
+              <article class="carousel__slide" data-carousel-slide>
+                <img
+                  src="https://images.unsplash.com/photo-1518607692857-0b868b512da1?auto=format&fit=crop&w=1600&q=80"
+                  alt="Basquete profissional com jogador arremessando em quadra iluminada"
+                  loading="lazy"
+                />
+                <div class="carousel__content">
+                  <span class="carousel__badge">Streaming premium</span>
+                  <h3>NBA Finals com odds turbinadas ao vivo</h3>
+                  <p>
+                    Assista em 4K, aproveite estatísticas em tempo real e boosts relâmpago a cada
+                    pedido de tempo.
+                  </p>
+                  <div class="carousel__actions">
+                    <button class="btn primary small" type="button">Assistir agora</button>
+                    <button class="btn ghost small" type="button">Ver calendário</button>
+                  </div>
+                </div>
+              </article>
+            </div>
+
+            <div class="carousel__dots" role="tablist" aria-label="Selecione um dos banners">
+              <button
+                class="carousel__dot is-active"
+                type="button"
+                data-carousel-dot="0"
+                aria-label="Ver primeiro banner"
+                aria-current="true"
+              ></button>
+              <button
+                class="carousel__dot"
+                type="button"
+                data-carousel-dot="1"
+                aria-label="Ver segundo banner"
+                aria-current="false"
+              ></button>
+              <button
+                class="carousel__dot"
+                type="button"
+                data-carousel-dot="2"
+                aria-label="Ver terceiro banner"
+                aria-current="false"
+              ></button>
+            </div>
+          </section>
+
           <section class="panel dashboard-section explosive-odds" data-animate="fade-up">
             <header class="dashboard-section__header">
               <div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GoleadaBet &mdash; Painel do jogador</title>
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="script.js"></script>
+  </head>
+  <body class="dashboard-page">
+    <header class="dashboard-header">
+      <div class="container dashboard-header__top">
+        <div class="logo">Goleada<span>Bet</span></div>
+        <form class="dashboard-search" role="search">
+          <label for="global-search" class="sr-only">Buscar eventos</label>
+          <span aria-hidden="true" class="search-icon">🔍</span>
+          <input
+            id="global-search"
+            type="search"
+            placeholder="Buscar campeonatos, times ou mercados"
+          />
+        </form>
+        <div class="header-widgets">
+          <div class="balance-card">
+            <span class="balance-label">Saldo disponível</span>
+            <strong class="balance-amount">R$ 1.275,00</strong>
+          </div>
+          <button class="btn primary small">Depositar</button>
+          <button class="btn ghost small">Sacar</button>
+          <div class="user-chip">
+            <span class="user-avatar" aria-hidden="true">LV</span>
+            <div>
+              <strong class="user-name">Lucas Vieira</strong>
+              <span class="user-tier">VIP Nível 3</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="dashboard-header__nav">
+        <div class="container dashboard-header__nav-inner">
+          <nav class="category-scroll" aria-label="Navegação principal">
+            <button class="category-button active" type="button">Início</button>
+            <button class="category-button" type="button">Ao vivo</button>
+            <button class="category-button" type="button">Futebol</button>
+            <button class="category-button" type="button">Basquete</button>
+            <button class="category-button" type="button">Tênis</button>
+            <button class="category-button" type="button">Esports</button>
+            <button class="category-button" type="button">Boost de Odds</button>
+            <button class="category-button" type="button">Promoções</button>
+            <button class="category-button" type="button">Resultados</button>
+          </nav>
+          <div class="live-ticker" role="status">
+            <span class="ticker-label">Próximo destaque</span>
+            <span class="ticker-match">Libertadores: Fluminense x Boca Juniors em 18 min</span>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main class="dashboard-main">
+      <div class="container dashboard-grid">
+        <aside class="dashboard-sidebar" aria-label="Listas de esportes e campeonatos">
+          <section class="sidebar-card panel">
+            <header class="sidebar-card__header">
+              <h2>Favoritos</h2>
+              <button class="link-button" type="button">Gerenciar</button>
+            </header>
+            <ul class="sidebar-list">
+              <li>
+                <span>Brasileirão Série A</span>
+                <span class="sidebar-pill live">AO VIVO</span>
+              </li>
+              <li>
+                <span>Champions League</span>
+                <span class="sidebar-pill">+21</span>
+              </li>
+              <li>
+                <span>NBA</span>
+                <span class="sidebar-pill">Playoffs</span>
+              </li>
+              <li>
+                <span>Premier League</span>
+                <span class="sidebar-pill">19:00</span>
+              </li>
+              <li>
+                <span>Libertadores</span>
+                <span class="sidebar-pill">Hoje</span>
+              </li>
+            </ul>
+          </section>
+
+          <section class="sidebar-card panel">
+            <header class="sidebar-card__header">
+              <h2>Campeonatos populares</h2>
+              <button class="link-button" type="button">Ver todos</button>
+            </header>
+            <ul class="sidebar-list secondary">
+              <li>La Liga</li>
+              <li>Serie A Italiana</li>
+              <li>Copa do Nordeste</li>
+              <li>Liga dos Campeões da Ásia</li>
+              <li>CBLOL</li>
+              <li>ATP Masters 1000</li>
+            </ul>
+          </section>
+
+          <section class="sidebar-card panel">
+            <header class="sidebar-card__header">
+              <h2>Mercados rápidos</h2>
+            </header>
+            <div class="quick-markets">
+              <button class="quick-market" type="button">Ambos marcam</button>
+              <button class="quick-market" type="button">Handicap -1.5</button>
+              <button class="quick-market" type="button">Mais de 2.5 gols</button>
+              <button class="quick-market" type="button">Primeiro tempo</button>
+              <button class="quick-market" type="button">Cartões &gt; 4.5</button>
+            </div>
+          </section>
+        </aside>
+
+        <div class="dashboard-content">
+          <section class="featured-live panel" data-animate="fade-up">
+            <div class="featured-live__info">
+              <span class="pill pill-live">Libertadores &bull; Ao vivo</span>
+              <h1>Fluminense x Boca Juniors</h1>
+              <p>
+                Final eletrizante no Maracanã. O Tricolor pressiona buscando a virada
+                enquanto o Boca se fecha para segurar a vantagem mínima.
+              </p>
+              <div class="scoreboard">
+                <div class="scoreboard-team">
+                  <span class="team-name">Fluminense</span>
+                  <strong class="team-score">1</strong>
+                </div>
+                <div class="scoreboard-status">
+                  <span class="status-minute">72'</span>
+                  <span class="status-period">2º tempo</span>
+                </div>
+                <div class="scoreboard-team">
+                  <span class="team-name">Boca Juniors</span>
+                  <strong class="team-score">2</strong>
+                </div>
+              </div>
+              <div class="featured-actions">
+                <button class="btn primary">Adicionar ao bilhete</button>
+                <button class="btn ghost">Assistir transmissão</button>
+              </div>
+            </div>
+            <div class="featured-live__markets">
+              <div class="market-block">
+                <span class="market-label">Resultado final</span>
+                <div class="market-options">
+                  <button class="odd-pill" type="button">1.92</button>
+                  <button class="odd-pill" type="button">3.25</button>
+                  <button class="odd-pill" type="button">4.10</button>
+                </div>
+              </div>
+              <div class="market-block">
+                <span class="market-label">Próximo gol</span>
+                <div class="market-options">
+                  <button class="odd-pill" type="button">Fluminense 2.30</button>
+                  <button class="odd-pill" type="button">Boca 3.05</button>
+                  <button class="odd-pill" type="button">Sem gol 3.60</button>
+                </div>
+              </div>
+              <div class="market-block">
+                <span class="market-label">Linha de gols</span>
+                <div class="market-options">
+                  <button class="odd-pill" type="button">Mais de 3.5 &mdash; 2.65</button>
+                  <button class="odd-pill" type="button">Menos de 3.5 &mdash; 1.48</button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="event-group panel" aria-labelledby="ao-vivo-agora">
+            <header class="group-header">
+              <div>
+                <h2 id="ao-vivo-agora">Ao vivo agora</h2>
+                <p>Atualizado em tempo real com cashout inteligente.</p>
+              </div>
+              <button class="link-button" type="button">Ver todos os eventos</button>
+            </header>
+            <div class="event-table" role="list">
+              <article class="event-row" role="listitem">
+                <div class="event-league">
+                  <span>Brasileirão Série A</span>
+                  <span class="event-minute">68'</span>
+                </div>
+                <div class="event-teams">
+                  <span>Fortaleza</span>
+                  <span class="event-score">1 &ndash; 0</span>
+                  <span>Internacional</span>
+                </div>
+                <div class="event-odds">
+                  <button class="odd-button" type="button">1.90</button>
+                  <button class="odd-button" type="button">3.45</button>
+                  <button class="odd-button" type="button">5.10</button>
+                </div>
+                <div class="event-extra">
+                  <span>+124 mercados</span>
+                </div>
+              </article>
+              <article class="event-row" role="listitem">
+                <div class="event-league">
+                  <span>NBA &bull; Playoffs</span>
+                  <span class="event-minute">Q4 04:12</span>
+                </div>
+                <div class="event-teams">
+                  <span>Lakers</span>
+                  <span class="event-score">102 &ndash; 98</span>
+                  <span>Warriors</span>
+                </div>
+                <div class="event-odds">
+                  <button class="odd-button" type="button">1.65</button>
+                  <button class="odd-button" type="button">12.50</button>
+                  <button class="odd-button" type="button">2.45</button>
+                </div>
+                <div class="event-extra">
+                  <span>Cashout Rápido</span>
+                </div>
+              </article>
+              <article class="event-row" role="listitem">
+                <div class="event-league">
+                  <span>ATP Madrid</span>
+                  <span class="event-minute">Set 3</span>
+                </div>
+                <div class="event-teams">
+                  <span>C. Alcaraz</span>
+                  <span class="event-score">6 &ndash; 4 &ndash; 5</span>
+                  <span>J. Sinner</span>
+                </div>
+                <div class="event-odds">
+                  <button class="odd-button" type="button">1.55</button>
+                  <button class="odd-button" type="button">2.55</button>
+                </div>
+                <div class="event-extra">
+                  <span>Tiebreak ativo</span>
+                </div>
+              </article>
+            </div>
+          </section>
+
+          <section class="event-group panel" aria-labelledby="boosts-dia">
+            <header class="group-header">
+              <div>
+                <h2 id="boosts-dia">Boosts do dia</h2>
+                <p>Odds turbinadas para slips selecionados.</p>
+              </div>
+              <button class="link-button" type="button">Termos</button>
+            </header>
+            <div class="boost-grid">
+              <article class="boost-card" data-animate="fade-up">
+                <span class="boost-label">+35%</span>
+                <h3>City vence + Haaland marca</h3>
+                <p>Odds aumentadas por tempo limitado para novos bilhetes simples.</p>
+                <div class="boost-odds">
+                  <span class="old-odds">2.10</span>
+                  <span class="new-odds">2.84</span>
+                </div>
+                <button class="btn primary small" type="button">Adicionar</button>
+              </article>
+              <article class="boost-card" data-animate="fade-up">
+                <span class="boost-label">+50%</span>
+                <h3>Real Madrid + Mais de 2.5</h3>
+                <p>Parlay exclusivo disponível até o início da partida.</p>
+                <div class="boost-odds">
+                  <span class="old-odds">3.40</span>
+                  <span class="new-odds">5.10</span>
+                </div>
+                <button class="btn primary small" type="button">Adicionar</button>
+              </article>
+              <article class="boost-card" data-animate="fade-up">
+                <span class="boost-label">+20%</span>
+                <h3>Vitória do Flamengo</h3>
+                <p>Válido para apostas simples até R$ 50 com cashout habilitado.</p>
+                <div class="boost-odds">
+                  <span class="old-odds">1.80</span>
+                  <span class="new-odds">2.16</span>
+                </div>
+                <button class="btn primary small" type="button">Adicionar</button>
+              </article>
+            </div>
+          </section>
+
+          <section class="event-group panel" aria-labelledby="agenda-dia">
+            <header class="group-header">
+              <div>
+                <h2 id="agenda-dia">Agenda do dia</h2>
+                <p>Não perca as partidas que você acompanha.</p>
+              </div>
+              <button class="link-button" type="button">Exportar</button>
+            </header>
+            <ul class="upcoming-list">
+              <li>
+                <div>
+                  <span class="upcoming-time">18:00</span>
+                  <strong>Palmeiras x São Paulo</strong>
+                  <span class="upcoming-league">Copa do Brasil &bull; Quartas</span>
+                </div>
+                <button class="odd-pill" type="button">Ver mercados</button>
+              </li>
+              <li>
+                <div>
+                  <span class="upcoming-time">19:30</span>
+                  <strong>Boston Celtics x Miami Heat</strong>
+                  <span class="upcoming-league">NBA &bull; Jogo 5</span>
+                </div>
+                <button class="odd-pill" type="button">Adicionar ao bilhete</button>
+              </li>
+              <li>
+                <div>
+                  <span class="upcoming-time">21:00</span>
+                  <strong>River Plate x Nacional</strong>
+                  <span class="upcoming-league">Libertadores &bull; Grupo D</span>
+                </div>
+                <button class="odd-pill" type="button">Pré-live</button>
+              </li>
+            </ul>
+          </section>
+        </div>
+
+        <aside class="dashboard-right" aria-label="Resumo da conta e bilhete">
+          <section class="betslip panel" aria-labelledby="bilhete-titulo">
+            <header class="betslip-header">
+              <h2 id="bilhete-titulo">Bilhete rápido</h2>
+              <span class="betslip-count">2 seleções</span>
+            </header>
+            <div class="betslip-selections">
+              <article class="selection">
+                <div>
+                  <span class="selection-league">Brasileirão Série B</span>
+                  <strong class="selection-match">Sport x Ceará</strong>
+                  <span class="selection-market">Vitória do Sport</span>
+                </div>
+                <button class="remove-selection" type="button" aria-label="Remover seleção">&times;</button>
+              </article>
+              <article class="selection">
+                <div>
+                  <span class="selection-league">Premier League</span>
+                  <strong class="selection-match">Arsenal x Newcastle</strong>
+                  <span class="selection-market">Mais de 2.5 gols</span>
+                </div>
+                <button class="remove-selection" type="button" aria-label="Remover seleção">&times;</button>
+              </article>
+            </div>
+            <div class="betslip-stake">
+              <label for="stake" class="stake-label">Valor da aposta</label>
+              <div class="stake-control">
+                <button type="button" class="stake-adjust">-</button>
+                <input id="stake" type="number" value="50" min="10" step="10" />
+                <button type="button" class="stake-adjust">+</button>
+              </div>
+              <div class="stake-summary">
+                <div>
+                  <span>Retorno potencial</span>
+                  <strong>R$ 612,50</strong>
+                </div>
+                <div>
+                  <span>Cashout disponível</span>
+                  <strong>R$ 128,40</strong>
+                </div>
+              </div>
+              <button class="btn primary full" type="button">Confirmar aposta</button>
+            </div>
+          </section>
+
+          <section class="account panel">
+            <h2>Resumo da conta</h2>
+            <dl class="account-stats">
+              <div>
+                <dt>Vencidas hoje</dt>
+                <dd>7</dd>
+              </div>
+              <div>
+                <dt>Apostas abertas</dt>
+                <dd>4</dd>
+              </div>
+              <div>
+                <dt>Cashout realizados</dt>
+                <dd>2</dd>
+              </div>
+            </dl>
+            <a class="link-button" href="#">Ver extrato completo</a>
+          </section>
+
+          <section class="support panel">
+            <h2>Suporte dedicado</h2>
+            <p>Estamos online 24 horas para tirar dúvidas e acompanhar suas apostas.</p>
+            <div class="support-actions">
+              <button class="btn primary small" type="button">Abrir chat</button>
+              <button class="btn ghost small" type="button">Central de ajuda</button>
+            </div>
+          </section>
+        </aside>
+      </div>
+    </main>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GoleadaBet &mdash; Sua casa de apostas esportivas</title>
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="container">
+        <span>Atendimento 24h</span>
+        <span>•</span>
+        <span>Depósito instantâneo</span>
+        <span>•</span>
+        <span>Licenciada e segura</span>
+      </div>
+    </header>
+
+    <nav class="main-nav">
+      <div class="container">
+        <div class="logo">Goleada<span>Bet</span></div>
+        <ul class="nav-links">
+          <li><a href="#inicio">Início</a></li>
+          <li><a href="#ao-vivo">Ao Vivo</a></li>
+          <li><a href="#eventos">Próximos Jogos</a></li>
+          <li><a href="#promocoes">Promoções</a></li>
+          <li><a href="#app">App Mobile</a></li>
+        </ul>
+        <div class="nav-actions">
+          <button class="btn ghost">Entrar</button>
+          <button class="btn primary">Criar Conta</button>
+        </div>
+      </div>
+    </nav>
+
+    <main>
+      <section class="hero" id="inicio">
+        <div class="container">
+          <div class="hero-content">
+            <h1>Faça sua aposta na melhor experiência esportiva do Brasil</h1>
+            <p>
+              Acompanhe partidas ao vivo com estatísticas em tempo real, mercados
+              exclusivos e pagamentos instantâneos. Entre em campo com odds de
+              elite e suporte dedicado 24 horas.
+            </p>
+            <div class="hero-actions">
+              <button class="btn primary">Apostar Agora</button>
+              <button class="btn ghost">Ver Calendário Completo</button>
+            </div>
+            <div class="hero-stats">
+              <div class="stat-card" data-animate="fade-up">
+                <span class="stat-value">+1.200</span>
+                <span class="stat-label">Eventos ao vivo por semana</span>
+              </div>
+              <div class="stat-card" data-animate="fade-up">
+                <span class="stat-value">94%</span>
+                <span class="stat-label">Taxa de retorno média</span>
+              </div>
+              <div class="stat-card" data-animate="fade-up">
+                <span class="stat-value">6</span>
+                <span class="stat-label">Mercados exclusivos de futebol</span>
+              </div>
+            </div>
+          </div>
+          <div class="hero-card" data-animate="fade-up">
+            <div class="hero-card__header">
+              <span class="live-dot"></span>
+              <span class="live-label">Ao vivo</span>
+              <span class="league">Brasileirão Série A</span>
+            </div>
+            <div class="hero-card__match">
+              <div class="team">
+                <span class="team-name">Atlético Mineiro</span>
+                <span class="team-score">2</span>
+              </div>
+              <div class="match-info">
+                <span>63'<span class="match-period"> 2º tempo</span></span>
+                <span class="stadium">Arena MRV</span>
+              </div>
+              <div class="team">
+                <span class="team-name">Flamengo</span>
+                <span class="team-score">1</span>
+              </div>
+            </div>
+            <div class="hero-card__markets">
+              <div>
+                <span>Resultado final</span>
+                <strong>1.95</strong>
+              </div>
+              <div>
+                <span>Próximo gol: Galo</span>
+                <strong>2.40</strong>
+              </div>
+              <div>
+                <span>Cantos &gt; 10.5</span>
+                <strong>1.82</strong>
+              </div>
+            </div>
+            <button class="btn primary full">Apostar com 10% extra</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="features" aria-label="Diferenciais">
+        <div class="container">
+          <article class="feature-card" data-animate="fade-up">
+            <h3>Streaming HD integrado</h3>
+            <p>
+              Assista aos principais campeonatos do mundo direto da plataforma e
+              combine estatísticas avançadas para apostar com precisão.
+            </p>
+          </article>
+          <article class="feature-card" data-animate="fade-up">
+            <h3>Cashout inteligente</h3>
+            <p>
+              Controle total do seu boleto: encerre apostas quando quiser com
+              cálculos instantâneos baseados em probabilidade real.
+            </p>
+          </article>
+          <article class="feature-card" data-animate="fade-up">
+            <h3>Bônus personalizado</h3>
+            <p>
+              Receba ofertas sob medida para seu perfil esportivo e acumule pontos
+              no nosso clube VIP para multiplicar ganhos.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="live-odds" id="ao-vivo" aria-labelledby="live-title">
+        <div class="container">
+          <div class="section-header">
+            <div>
+              <h2 id="live-title">Mercados ao vivo em destaque</h2>
+              <p>Atualizados em tempo real com liquidez garantida.</p>
+            </div>
+            <div class="filters">
+              <button class="filter-button active" data-sport="all">
+                Todos
+              </button>
+              <button class="filter-button" data-sport="futebol">
+                Futebol
+              </button>
+              <button class="filter-button" data-sport="basquete">
+                Basquete
+              </button>
+              <button class="filter-button" data-sport="tenis">Tênis</button>
+            </div>
+          </div>
+          <div class="odds-grid">
+            <article class="odds-card" data-sport="futebol" data-animate="fade-up">
+              <header>
+                <span class="league">UEFA Champions League</span>
+                <span class="timer">37' 1º T</span>
+              </header>
+              <div class="match">
+                <div class="club">
+                  <span>Manchester City</span>
+                  <strong>1.62</strong>
+                </div>
+                <div class="club">
+                  <span>Empate</span>
+                  <strong>3.90</strong>
+                </div>
+                <div class="club">
+                  <span>Real Madrid</span>
+                  <strong>4.55</strong>
+                </div>
+              </div>
+              <footer>
+                <span>Mercados extras: +124</span>
+                <button class="btn ghost">Abrir</button>
+              </footer>
+            </article>
+
+            <article class="odds-card" data-sport="basquete" data-animate="fade-up">
+              <header>
+                <span class="league">NBA Playoffs</span>
+                <span class="timer">Q3 05:42</span>
+              </header>
+              <div class="match">
+                <div class="club">
+                  <span>Lakers</span>
+                  <strong>1.85</strong>
+                </div>
+                <div class="club">
+                  <span>Celtics</span>
+                  <strong>2.05</strong>
+                </div>
+              </div>
+              <div class="split-line"></div>
+              <div class="stat-line">
+                <span>Total pontos: 212.5</span>
+                <strong>1.90</strong>
+              </div>
+              <footer>
+                <span>Mercados extras: +76</span>
+                <button class="btn ghost">Abrir</button>
+              </footer>
+            </article>
+
+            <article class="odds-card" data-sport="tenis" data-animate="fade-up">
+              <header>
+                <span class="league">Roland Garros</span>
+                <span class="timer">Set 3</span>
+              </header>
+              <div class="match">
+                <div class="club">
+                  <span>Nadal</span>
+                  <strong>1.47</strong>
+                </div>
+                <div class="club">
+                  <span>Djokovic</span>
+                  <strong>2.55</strong>
+                </div>
+              </div>
+              <div class="stat-line">
+                <span>Games totais &lt; 38.5</span>
+                <strong>1.72</strong>
+              </div>
+              <footer>
+                <span>Mercados extras: +32</span>
+                <button class="btn ghost">Abrir</button>
+              </footer>
+            </article>
+
+            <article class="odds-card" data-sport="futebol" data-animate="fade-up">
+              <header>
+                <span class="league">Libertadores</span>
+                <span class="timer">22:00</span>
+              </header>
+              <div class="match">
+                <div class="club">
+                  <span>Palmeiras</span>
+                  <strong>1.75</strong>
+                </div>
+                <div class="club">
+                  <span>Empate</span>
+                  <strong>3.25</strong>
+                </div>
+                <div class="club">
+                  <span>Boca Juniors</span>
+                  <strong>4.10</strong>
+                </div>
+              </div>
+              <div class="stat-line">
+                <span>Ambas marcam: Sim</span>
+                <strong>1.95</strong>
+              </div>
+              <footer>
+                <span>Mercados extras: +98</span>
+                <button class="btn ghost">Abrir</button>
+              </footer>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="upcoming" id="eventos">
+        <div class="container">
+          <div class="section-header">
+            <div>
+              <h2>Próximos confrontos imperdíveis</h2>
+              <p>Planeje suas apostas com antecedência e aproveite boosts exclusivos.</p>
+            </div>
+            <button class="btn ghost">Ver agenda completa</button>
+          </div>
+          <div class="schedule">
+            <article data-animate="fade-up">
+              <span class="tag">Futebol</span>
+              <h3>Clássico Paulista</h3>
+              <p>Corinthians x São Paulo &bull; Dom 18:00</p>
+              <div class="odds">
+                <span>1: 2.35</span>
+                <span>X: 3.10</span>
+                <span>2: 3.05</span>
+              </div>
+            </article>
+            <article data-animate="fade-up">
+              <span class="tag">Basquete</span>
+              <h3>Final NBB</h3>
+              <p>Flamengo x Franca &bull; Sáb 21:30</p>
+              <div class="odds">
+                <span>Flamengo: 1.72</span>
+                <span>Franca: 2.15</span>
+              </div>
+            </article>
+            <article data-animate="fade-up">
+              <span class="tag">Tênis</span>
+              <h3>Final WTA Rio</h3>
+              <p>Beatriz Haddad Maia x Sabalenka &bull; Seg 15:00</p>
+              <div class="odds">
+                <span>Haddad Maia: 2.60</span>
+                <span>Sabalenka: 1.55</span>
+              </div>
+            </article>
+            <article data-animate="fade-up">
+              <span class="tag">E-sports</span>
+              <h3>CBLOL Playoffs</h3>
+              <p>LOUD x paiN Gaming &bull; Sáb 17:00</p>
+              <div class="odds">
+                <span>LOUD: 1.65</span>
+                <span>paiN: 2.20</span>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="promotions" id="promocoes">
+        <div class="container">
+          <div class="section-header">
+            <div>
+              <h2>Ofertas para turbinar suas apostas</h2>
+              <p>Boost de odds, freebets semanais e missão especial por esporte.</p>
+            </div>
+            <button class="btn primary">Resgatar bônus</button>
+          </div>
+          <div class="promo-grid">
+            <article class="promo-card" data-animate="fade-up">
+              <h3>Missão Brasileirão</h3>
+              <p>
+                Aposte em 3 partidas da rodada e receba 50% de freebet extra no
+                seu maior ganho.
+              </p>
+              <span class="bonus">+50% de bônus</span>
+            </article>
+            <article class="promo-card" data-animate="fade-up">
+              <h3>Cashback NBA</h3>
+              <p>
+                Receba 20% de volta em apostas ao vivo no quarto período para não
+                perder nenhum arremesso decisivo.
+              </p>
+              <span class="bonus">Cashback 20%</span>
+            </article>
+            <article class="promo-card" data-animate="fade-up">
+              <h3>Combo de Múltiplas</h3>
+              <p>
+                Aumente até 150% das suas múltiplas com 4 seleções ou mais em
+                qualquer modalidade disponível.
+              </p>
+              <span class="bonus">+150% de boost</span>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="app-banner" id="app">
+        <div class="container">
+          <div class="app-content" data-animate="fade-up">
+            <h2>Experiência mobile completa</h2>
+            <p>
+              Aposte, faça cashout e acompanhe o streaming onde estiver. Nosso
+              aplicativo está disponível para iOS e Android com notificações em
+              tempo real e login biométrico.
+            </p>
+            <div class="store-buttons">
+              <a class="store apple" href="#">Baixar para iOS</a>
+              <a class="store android" href="#">Baixar para Android</a>
+            </div>
+          </div>
+          <div class="app-phones" aria-hidden="true" data-animate="fade-up">
+            <div class="phone"></div>
+            <div class="phone secondary"></div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container">
+        <div class="footer-brand">
+          <div class="logo">Goleada<span>Bet</span></div>
+          <p>Jogue com responsabilidade. Proibido para menores de 18 anos.</p>
+        </div>
+        <div class="footer-links">
+          <div>
+            <h4>Produtos</h4>
+            <a href="#ao-vivo">Apostas ao vivo</a>
+            <a href="#eventos">Calendário</a>
+            <a href="#promocoes">Bônus</a>
+          </div>
+          <div>
+            <h4>Suporte</h4>
+            <a href="#">Central de ajuda</a>
+            <a href="#">Política de privacidade</a>
+            <a href="#">Jogo responsável</a>
+          </div>
+          <div>
+            <h4>Comunidade</h4>
+            <a href="#">Blog</a>
+            <a href="#">Afiliados</a>
+            <a href="#">Carreiras</a>
+          </div>
+        </div>
+        <div class="footer-social">
+          <span>Siga nossas redes:</span>
+          <div class="social-links">
+            <a href="#" aria-label="Instagram">Instagram</a>
+            <a href="#" aria-label="YouTube">YouTube</a>
+            <a href="#" aria-label="Twitter">Twitter</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -47,10 +47,102 @@ const initRevealAnimations = () => {
   elements.forEach((element) => observer.observe(element));
 };
 
+const initRotatingBanners = () => {
+  const carousels = document.querySelectorAll('[data-carousel]');
+
+  if (!carousels.length) return;
+
+  carousels.forEach((carousel) => {
+    const slides = Array.from(carousel.querySelectorAll('[data-carousel-slide]'));
+
+    if (!slides.length) return;
+
+    const prevButton = carousel.querySelector('[data-carousel-prev]');
+    const nextButton = carousel.querySelector('[data-carousel-next]');
+    const dots = Array.from(carousel.querySelectorAll('[data-carousel-dot]'));
+
+    let activeIndex = slides.findIndex((slide) => slide.classList.contains('is-active'));
+    if (activeIndex < 0) activeIndex = 0;
+
+    const setActiveSlide = (index) => {
+      if (!slides.length) return;
+
+      const normalizedIndex = ((index % slides.length) + slides.length) % slides.length;
+
+      slides.forEach((slide, slideIndex) => {
+        const isActive = slideIndex === normalizedIndex;
+        slide.classList.toggle('is-active', isActive);
+        slide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+      });
+
+      dots.forEach((dot, dotIndex) => {
+        const isActive = dotIndex === normalizedIndex;
+        dot.classList.toggle('is-active', isActive);
+        dot.setAttribute('aria-current', isActive ? 'true' : 'false');
+      });
+
+      activeIndex = normalizedIndex;
+    };
+
+    setActiveSlide(activeIndex);
+
+    const goNext = () => setActiveSlide(activeIndex + 1);
+    const goPrev = () => setActiveSlide(activeIndex - 1);
+
+    let autoTimer;
+
+    const stopAuto = () => {
+      if (autoTimer) {
+        clearInterval(autoTimer);
+        autoTimer = undefined;
+      }
+    };
+
+    const startAuto = () => {
+      if (slides.length <= 1) return;
+      stopAuto();
+      autoTimer = setInterval(goNext, 7000);
+    };
+
+    if (prevButton) {
+      prevButton.addEventListener('click', () => {
+        goPrev();
+        startAuto();
+      });
+    }
+
+    if (nextButton) {
+      nextButton.addEventListener('click', () => {
+        goNext();
+        startAuto();
+      });
+    }
+
+    dots.forEach((dot, dotIndex) => {
+      dot.addEventListener('click', () => {
+        setActiveSlide(dotIndex);
+        startAuto();
+      });
+    });
+
+    carousel.addEventListener('mouseenter', stopAuto);
+    carousel.addEventListener('mouseleave', startAuto);
+    carousel.addEventListener('focusin', stopAuto);
+    carousel.addEventListener('focusout', (event) => {
+      if (!carousel.contains(event.relatedTarget)) {
+        startAuto();
+      }
+    });
+
+    startAuto();
+  });
+};
+
 const enhance = () => {
   document.documentElement.classList.add('js');
   initLiveFilters();
   initRevealAnimations();
+  initRotatingBanners();
 };
 
 document.addEventListener('DOMContentLoaded', enhance);

--- a/script.js
+++ b/script.js
@@ -1,0 +1,56 @@
+const initLiveFilters = () => {
+  const buttons = document.querySelectorAll('.filter-button');
+  const cards = document.querySelectorAll('.odds-card');
+
+  if (!buttons.length) return;
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const sport = button.dataset.sport;
+
+      buttons.forEach((btn) => btn.classList.remove('active'));
+      button.classList.add('active');
+
+      cards.forEach((card) => {
+        if (sport === 'all' || card.dataset.sport === sport) {
+          card.classList.remove('hidden');
+          card.style.pointerEvents = '';
+        } else {
+          card.classList.add('hidden');
+          card.style.pointerEvents = 'none';
+        }
+      });
+    });
+  });
+};
+
+const initRevealAnimations = () => {
+  const elements = document.querySelectorAll('[data-animate="fade-up"]');
+
+  if (!('IntersectionObserver' in window)) {
+    elements.forEach((element) => element.classList.add('in-view'));
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('in-view');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.2 }
+  );
+
+  elements.forEach((element) => observer.observe(element));
+};
+
+const enhance = () => {
+  document.documentElement.classList.add('js');
+  initLiveFilters();
+  initRevealAnimations();
+};
+
+document.addEventListener('DOMContentLoaded', enhance);

--- a/styles.css
+++ b/styles.css
@@ -776,3 +776,974 @@ main section {
     align-items: stretch;
   }
 }
+
+/* ===== Dashboard (área logada) ===== */
+body.dashboard-page {
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.2), transparent)
+      0 0/100% 320px no-repeat,
+    radial-gradient(circle at center right, rgba(22, 241, 180, 0.08), transparent 60%),
+    var(--color-background);
+}
+
+body.dashboard-page .container {
+  width: min(1280px, 95vw);
+}
+
+body.dashboard-page main section {
+  padding: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.dashboard-header {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: rgba(5, 7, 15, 0.96);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.55);
+}
+
+.dashboard-header__top {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.1rem 0;
+}
+
+.dashboard-search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  color: var(--color-muted);
+}
+
+.dashboard-search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  outline: none;
+}
+
+.dashboard-search input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.search-icon {
+  font-size: 1rem;
+}
+
+.header-widgets {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.balance-card {
+  background: var(--gradient-highlight);
+  padding: 0.65rem 1.1rem;
+  border-radius: var(--radius-sm);
+  color: #021219;
+  min-width: 170px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: 0 14px 35px rgba(22, 241, 180, 0.25);
+}
+
+.balance-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.balance-amount {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.btn.small {
+  padding: 0.55rem 1.1rem;
+  font-size: 0.85rem;
+}
+
+.user-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem 0.45rem 0.45rem;
+}
+
+.user-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: var(--gradient-primary);
+  color: #021219;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.user-name {
+  font-size: 0.95rem;
+}
+
+.user-tier {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.dashboard-header__nav {
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(5, 7, 15, 0.92);
+}
+
+.dashboard-header__nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.85rem 0;
+}
+
+.category-scroll {
+  display: flex;
+  gap: 0.6rem;
+  overflow-x: auto;
+  padding-bottom: 0.3rem;
+  scrollbar-width: none;
+}
+
+.category-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.category-button {
+  border: none;
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--color-muted);
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.category-button:hover {
+  color: var(--color-highlight);
+}
+
+.category-button.active {
+  background: var(--gradient-highlight);
+  color: #021219;
+  box-shadow: 0 10px 30px rgba(22, 241, 180, 0.25);
+}
+
+.live-ticker {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.ticker-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--color-highlight);
+}
+
+.dashboard-main {
+  padding: 2.75rem 0 4rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) 320px;
+  gap: 1.8rem;
+  align-items: flex-start;
+}
+
+.dashboard-sidebar,
+.dashboard-content,
+.dashboard-right {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-page .panel {
+  background: rgba(8, 13, 23, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(16px);
+}
+
+.sidebar-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.2rem;
+  gap: 0.75rem;
+}
+
+.sidebar-card h2 {
+  font-size: 1.05rem;
+}
+
+.sidebar-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.sidebar-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: var(--radius-sm);
+  padding: 0.65rem 0.75rem;
+  transition: background 0.3s ease;
+  font-size: 0.9rem;
+}
+
+.sidebar-list li:hover {
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.sidebar-list.secondary li {
+  background: transparent;
+  padding: 0.4rem 0;
+  color: var(--color-muted);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 0;
+}
+
+.sidebar-list.secondary li:last-child {
+  border-bottom: none;
+}
+
+.sidebar-pill {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--color-muted);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+}
+
+.sidebar-pill.live {
+  background: rgba(248, 113, 113, 0.18);
+  color: #f87171;
+}
+
+.quick-markets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.quick-market {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--color-muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.quick-market:hover {
+  background: rgba(37, 99, 235, 0.22);
+  color: var(--color-highlight);
+}
+
+.featured-live {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 2.25rem;
+  padding: 2.1rem 2.4rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.3), rgba(14, 165, 233, 0.08));
+}
+
+.featured-live::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(22, 241, 180, 0.28), transparent 55%);
+  pointer-events: none;
+}
+
+.featured-live__info {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: rgba(15, 23, 42, 0.65);
+  color: var(--color-highlight);
+  font-weight: 700;
+}
+
+.pill-live {
+  background: rgba(248, 113, 113, 0.15);
+  color: #f87171;
+}
+
+.featured-live h1 {
+  font-size: clamp(1.8rem, 3.4vw, 2.6rem);
+}
+
+.scoreboard {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: 1.5rem;
+  margin: 1.5rem 0;
+}
+
+.scoreboard-team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.scoreboard-team:last-child {
+  align-items: flex-end;
+}
+
+.team-score {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  font-weight: 700;
+  color: var(--color-highlight);
+}
+
+.scoreboard-status {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.featured-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.featured-live__markets {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  background: rgba(5, 7, 15, 0.55);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1.5rem;
+}
+
+.market-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.market-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  font-weight: 600;
+}
+
+.market-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.odd-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.55rem 1.1rem;
+  background: rgba(8, 13, 23, 0.75);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.odd-pill:hover {
+  border-color: rgba(22, 241, 180, 0.55);
+  color: var(--color-highlight);
+}
+
+.event-group {
+  gap: 1.4rem;
+}
+
+.group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.2rem;
+}
+
+.group-header p {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: var(--color-highlight);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
+.event-table {
+  display: flex;
+  flex-direction: column;
+}
+
+.event-row {
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr) 220px 120px;
+  align-items: center;
+  gap: 1.2rem;
+  padding: 1rem 1.2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  transition: background 0.3s ease;
+}
+
+.event-row:first-child {
+  border-top: none;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+}
+
+.event-row:last-child {
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+}
+
+.event-row:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.event-league span:first-child {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.event-minute {
+  display: inline-block;
+  margin-top: 0.35rem;
+  font-weight: 600;
+  color: var(--color-highlight);
+}
+
+.event-teams {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 0.75rem;
+  font-weight: 600;
+  align-items: center;
+}
+
+.event-score {
+  font-size: 1.2rem;
+  color: var(--color-highlight);
+}
+
+.event-odds {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.odd-button {
+  border: 1px solid rgba(22, 241, 180, 0.4);
+  background: rgba(22, 241, 180, 0.12);
+  color: var(--color-highlight);
+  font-weight: 600;
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.odd-button:hover {
+  transform: translateY(-2px);
+  background: rgba(22, 241, 180, 0.2);
+}
+
+.event-extra {
+  text-align: right;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.boost-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.boost-card {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 1.6rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(59, 130, 246, 0.24);
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.9), rgba(37, 99, 235, 0.18));
+}
+
+.boost-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.35), transparent 60%);
+  pointer-events: none;
+}
+
+.boost-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.boost-label {
+  align-self: flex-start;
+  background: var(--gradient-highlight);
+  color: #021219;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.boost-card h3 {
+  font-size: 1.1rem;
+}
+
+.boost-card p {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.boost-odds {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.old-odds {
+  color: var(--color-muted);
+  text-decoration: line-through;
+}
+
+.new-odds {
+  font-size: 1.35rem;
+  color: var(--color-highlight);
+}
+
+.upcoming-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.upcoming-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(15, 23, 42, 0.45);
+  transition: border 0.3s ease;
+}
+
+.upcoming-list li:hover {
+  border-color: rgba(22, 241, 180, 0.45);
+}
+
+.upcoming-time {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-highlight);
+}
+
+.upcoming-league {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.betslip {
+  gap: 1.2rem;
+}
+
+.betslip-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  padding-bottom: 0.9rem;
+}
+
+.betslip-count {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.selection {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.selection:last-child {
+  border-bottom: none;
+}
+
+.selection-league {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.selection-match {
+  font-size: 0.95rem;
+}
+
+.selection-market {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.remove-selection {
+  background: none;
+  border: none;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+
+.remove-selection:hover {
+  color: var(--color-highlight);
+}
+
+.betslip-stake {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-top: 0.8rem;
+}
+
+.stake-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.stake-control {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.25rem;
+}
+
+.stake-control input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  text-align: center;
+  font-size: 1.05rem;
+  font-weight: 600;
+  min-width: 0;
+}
+
+.stake-control input:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.55);
+  border-radius: var(--radius-sm);
+}
+
+.stake-adjust {
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: rgba(22, 241, 180, 0.12);
+  color: var(--color-highlight);
+  border-radius: var(--radius-sm);
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.stake-adjust:hover {
+  background: rgba(22, 241, 180, 0.22);
+}
+
+.stake-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.stake-summary strong {
+  display: block;
+  color: var(--color-highlight);
+  font-size: 1.05rem;
+}
+
+.account h2,
+.support h2 {
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.account-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.2rem;
+}
+
+.account-stats div {
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: var(--radius-sm);
+  padding: 0.8rem;
+  text-align: center;
+}
+
+.account-stats dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.account-stats dd {
+  margin-top: 0.35rem;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--color-highlight);
+}
+
+.support p {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  margin-bottom: 1.2rem;
+}
+
+.support-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 1280px) {
+  .dashboard-grid {
+    grid-template-columns: 220px minmax(0, 1fr) 300px;
+  }
+}
+
+@media (max-width: 1150px) {
+  .dashboard-grid {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+
+  .dashboard-right {
+    order: 3;
+  }
+
+  .dashboard-right .panel {
+    width: 100%;
+  }
+}
+
+@media (max-width: 1024px) {
+  .dashboard-header__top {
+    flex-wrap: wrap;
+  }
+
+  .header-widgets {
+    width: 100%;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .dashboard-search {
+    order: 3;
+    width: 100%;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard-sidebar {
+    order: 2;
+  }
+
+  .dashboard-content {
+    order: 1;
+  }
+
+  .dashboard-right {
+    order: 3;
+  }
+
+  .featured-live {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard-header__nav-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .live-ticker {
+    white-space: normal;
+    align-self: stretch;
+  }
+
+  .event-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.85rem;
+    text-align: left;
+  }
+
+  .event-extra {
+    text-align: left;
+  }
+
+  .boost-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stake-summary {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .account-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 580px) {
+  .dashboard-header__top {
+    gap: 1rem;
+  }
+
+  .header-widgets {
+    justify-content: space-between;
+  }
+
+  .boost-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .upcoming-list li {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .account-stats {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1747,3 +1747,1250 @@ body.dashboard-page main section {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+/* ===== Dashboard redesign overrides ===== */
+body.dashboard-page {
+  background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.18), transparent 55%),
+    radial-gradient(circle at 18% 30%, rgba(16, 185, 129, 0.12), transparent 60%),
+    var(--color-background);
+}
+
+body.dashboard-page .container {
+  width: min(1320px, 94vw);
+}
+
+.dashboard-main {
+  padding: clamp(2.5rem, 5vw, 4rem) 0 3.5rem;
+}
+
+.dashboard-header {
+  position: sticky;
+  top: 0;
+  z-index: 80;
+  background: rgba(5, 8, 18, 0.95);
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 20px 45px rgba(2, 6, 23, 0.6);
+}
+
+.dashboard-header__top {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.15rem 0;
+}
+
+.dashboard-search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  color: var(--color-muted);
+}
+
+.dashboard-search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  outline: none;
+}
+
+.dashboard-search input::placeholder {
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.search-icon {
+  font-size: 1rem;
+}
+
+.header-widgets {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.balance-card {
+  background: var(--gradient-highlight);
+  padding: 0.7rem 1.1rem;
+  border-radius: var(--radius-sm);
+  color: #021219;
+  min-width: 170px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  box-shadow: 0 18px 40px rgba(22, 241, 180, 0.25);
+}
+
+.balance-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.balance-amount {
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.btn.small {
+  padding: 0.55rem 1.1rem;
+  font-size: 0.85rem;
+}
+
+.user-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem 0.45rem 0.45rem;
+}
+
+.user-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--gradient-primary);
+  color: #0b1120;
+  font-weight: 700;
+}
+
+.user-name {
+  display: block;
+  font-weight: 600;
+}
+
+.user-tier {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.dashboard-header__nav {
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(5, 10, 20, 0.9);
+}
+
+.dashboard-header__nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.85rem 0;
+}
+
+.category-scroll {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
+}
+
+.category-scroll::-webkit-scrollbar {
+  height: 4px;
+}
+
+.category-scroll::-webkit-scrollbar-thumb {
+  background: rgba(59, 130, 246, 0.35);
+  border-radius: 999px;
+}
+
+.category-button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.7);
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  white-space: nowrap;
+}
+
+.category-button:hover {
+  color: var(--color-highlight);
+}
+
+.category-button.active {
+  background: rgba(37, 99, 235, 0.22);
+  border-color: rgba(37, 99, 235, 0.35);
+  color: #bfdbfe;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.28);
+}
+
+.live-ticker {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+  white-space: nowrap;
+}
+
+.ticker-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(147, 197, 253, 0.85);
+}
+
+.ticker-match {
+  font-weight: 600;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: var(--color-highlight);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: color 0.3s ease;
+}
+
+.link-button:hover {
+  color: #e0f2fe;
+  text-decoration: underline;
+}
+
+.dashboard-shell {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 320px;
+  grid-template-areas: "aside main slip";
+  gap: 1.75rem;
+  align-items: start;
+}
+
+.shell-left {
+  grid-area: aside;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.shell-center {
+  grid-area: main;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.shell-right {
+  grid-area: slip;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-page .panel {
+  position: relative;
+  background: linear-gradient(160deg, rgba(14, 20, 38, 0.92), rgba(8, 12, 26, 0.82));
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: var(--radius-md);
+  padding: 1.6rem;
+  box-shadow: 0 26px 60px rgba(2, 8, 23, 0.45);
+  backdrop-filter: blur(16px);
+}
+
+.dashboard-page .panel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 15% -10%, rgba(59, 130, 246, 0.15), transparent 55%);
+  pointer-events: none;
+}
+
+.dashboard-page .panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.side-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+}
+
+.side-panel h2 {
+  font-size: 1.05rem;
+}
+
+.side-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.side-search {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 999px;
+  padding: 0.55rem 0.95rem;
+  color: var(--color-muted);
+}
+
+.side-search input {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-size: 0.92rem;
+  outline: none;
+}
+
+.side-search input::placeholder {
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.side-search__icon {
+  font-size: 1rem;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
+  background: rgba(8, 13, 23, 0.6);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.85rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.chip:hover {
+  border-color: rgba(59, 130, 246, 0.4);
+  color: var(--color-highlight);
+}
+
+.chip.active {
+  background: rgba(22, 241, 180, 0.18);
+  border-color: rgba(22, 241, 180, 0.45);
+  color: var(--color-highlight);
+}
+.favorite-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.favorite-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.55);
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.favorite-list li:hover {
+  background: rgba(37, 99, 235, 0.18);
+  transform: translateX(4px);
+}
+
+.favorite-list .tag {
+  font-size: 0.68rem;
+}
+
+.sports-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.sports-accordion details {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(10, 17, 32, 0.78);
+  overflow: hidden;
+  transition: border-color 0.3s ease, transform 0.3s ease;
+}
+
+.sports-accordion details:hover {
+  border-color: rgba(59, 130, 246, 0.35);
+  transform: translateY(-2px);
+}
+
+.sports-accordion summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 0.85rem 1rem;
+  list-style: none;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--color-text);
+  position: relative;
+}
+
+.sports-accordion summary::-webkit-details-marker {
+  display: none;
+}
+
+.sports-accordion summary::after {
+  content: "▾";
+  font-size: 1rem;
+  color: rgba(226, 232, 240, 0.55);
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.sports-accordion details[open] summary::after {
+  transform: rotate(180deg);
+  color: var(--color-highlight);
+}
+
+.accordion-title {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.accordion-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.75rem;
+  display: grid;
+  place-items: center;
+  background: rgba(37, 99, 235, 0.18);
+  font-size: 1rem;
+}
+
+.accordion-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.22);
+  color: var(--color-highlight);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sports-accordion details[open] summary {
+  background: rgba(37, 99, 235, 0.12);
+  border-bottom: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.sports-accordion ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem 1.05rem;
+}
+
+.sports-accordion li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.55);
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.sports-accordion li:hover {
+  background: rgba(37, 99, 235, 0.2);
+  transform: translateX(6px);
+}
+
+body.dashboard-page .tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+body.dashboard-page .tag.live {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fda4af;
+}
+
+body.dashboard-page .tag.soon {
+  background: rgba(37, 99, 235, 0.2);
+  color: #93c5fd;
+}
+
+body.dashboard-page .tag.boost {
+  background: rgba(22, 241, 180, 0.18);
+  color: var(--color-highlight);
+}
+
+.section-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.18);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.dashboard-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.dashboard-section__header p {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.95rem;
+}
+
+.dashboard-section__header .link-button {
+  white-space: nowrap;
+}
+
+.hero-banner {
+  padding: clamp(2.4rem, 4.8vw, 3.4rem);
+  border-radius: var(--radius-lg);
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 32px 60px rgba(7, 22, 54, 0.45);
+  overflow: hidden;
+  color: #f8fafc;
+  gap: clamp(1.4rem, 3vw, 2rem);
+}
+
+.hero-banner::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      120deg,
+      rgba(2, 6, 23, 0.92) 10%,
+      rgba(2, 6, 23, 0.65) 45%,
+      rgba(2, 6, 23, 0.25)
+    ),
+    var(--hero-image, linear-gradient(135deg, #0f172a, #1e3a8a));
+  background-size: cover;
+  background-position: center;
+  filter: saturate(1.1);
+  transform: scale(1.05);
+  z-index: 0;
+}
+
+.hero-banner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 90% 20%, rgba(59, 130, 246, 0.3), transparent 55%);
+  z-index: 0;
+}
+
+.hero-banner > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-banner h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  line-height: 1.1;
+}
+
+.hero-banner p {
+  color: rgba(241, 245, 249, 0.85);
+  max-width: 520px;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.hero-score {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1.2rem 1.4rem;
+  border-radius: var(--radius-md);
+  background: rgba(2, 6, 23, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.hero-team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.hero-team span:first-child {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero-team strong {
+  font-size: clamp(2.2rem, 4.6vw, 3.2rem);
+  font-weight: 700;
+  color: var(--color-highlight);
+}
+
+.hero-team--right {
+  text-align: right;
+  align-items: flex-end;
+}
+
+.hero-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.hero-status span {
+  display: block;
+}
+
+.hero-markets {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.hero-market {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(2, 6, 23, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.hero-market__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.65);
+  font-weight: 600;
+}
+
+.hero-market__odds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.odd-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(8, 13, 23, 0.68);
+  color: rgba(226, 232, 240, 0.9);
+  font-weight: 600;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.odd-chip:hover {
+  border-color: rgba(22, 241, 180, 0.55);
+  color: var(--color-highlight);
+  box-shadow: 0 0 0 3px rgba(22, 241, 180, 0.18);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+}
+
+.explosive-odds {
+  border-radius: var(--radius-lg);
+}
+
+.odds-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.4rem;
+}
+
+.odd-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.4rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(170deg, rgba(37, 99, 235, 0.25), rgba(14, 165, 233, 0.05));
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  box-shadow: 0 24px 50px rgba(8, 47, 73, 0.32);
+  overflow: hidden;
+}
+
+.odd-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 15% -20%, rgba(22, 241, 180, 0.18), transparent 60%);
+  pointer-events: none;
+}
+
+.odd-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.odd-card__teams {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.odd-card__teams span {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.odd-card__markets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.odd-card__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.6);
+  font-weight: 600;
+}
+
+.odd-card__odds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.odd-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.78rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.live-now .live-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+}
+
+.live-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.1rem;
+  border-radius: var(--radius-md);
+  background: rgba(8, 13, 23, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.live-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.35);
+  box-shadow: 0 16px 35px rgba(8, 47, 73, 0.3);
+}
+
+.live-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.live-card__teams {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.live-card__teams span {
+  font-size: 0.78rem;
+  color: rgba(226, 232, 240, 0.6);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.live-card__score {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.live-card__odds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.betslip {
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(8, 12, 26, 0.85));
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  box-shadow: 0 32px 60px rgba(7, 22, 54, 0.45);
+  gap: 1.35rem;
+}
+
+.betslip__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.betslip__header h2 {
+  font-size: 1.25rem;
+}
+
+.betslip__label {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.betslip__status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.betslip__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.betslip-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(2, 6, 23, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.betslip-item__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.betslip-item h3 {
+  font-size: 1rem;
+}
+
+.betslip-market {
+  font-size: 0.86rem;
+  color: rgba(226, 232, 240, 0.68);
+}
+
+.betslip-odd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  font-weight: 600;
+}
+
+.betslip-remove {
+  background: none;
+  border: none;
+  color: rgba(148, 163, 184, 0.65);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+
+.betslip-remove:hover {
+  color: var(--color-highlight);
+}
+
+.betslip__stake {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stake-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+  font-weight: 600;
+}
+
+.stake-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.stake-control input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  text-align: center;
+  font-weight: 700;
+  font-size: 1.05rem;
+  min-width: 0;
+  outline: none;
+}
+
+.stake-adjust {
+  width: 38px;
+  height: 38px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: rgba(37, 99, 235, 0.2);
+  color: #bfdbfe;
+  font-size: 1.05rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.stake-adjust:hover {
+  background: rgba(37, 99, 235, 0.35);
+  color: var(--color-highlight);
+}
+
+.betslip__quick {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quick-amount {
+  border: 1px solid rgba(96, 165, 250, 0.28);
+  border-radius: var(--radius-sm);
+  background: rgba(12, 18, 34, 0.82);
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.quick-amount:hover {
+  border-color: var(--color-highlight);
+  color: var(--color-highlight);
+}
+
+.betslip__totals {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.betslip__totals dt {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.betslip__totals dd {
+  margin-top: 0.35rem;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-highlight);
+}
+
+.betslip__disclaimer {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.55);
+}
+
+.highlight-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(150deg, rgba(22, 241, 180, 0.18), rgba(37, 99, 235, 0.12));
+  border: 1px solid rgba(22, 241, 180, 0.25);
+  box-shadow: 0 24px 50px rgba(6, 78, 59, 0.35);
+}
+
+.highlight-card p {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.support-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.support-card p {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.95rem;
+}
+
+.support-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.support-actions .chip {
+  border-color: rgba(59, 130, 246, 0.3);
+  background: rgba(59, 130, 246, 0.16);
+  color: #bfdbfe;
+}
+
+.support-actions .chip:hover {
+  background: rgba(59, 130, 246, 0.3);
+  color: #e0f2fe;
+}
+
+.category-button:focus-visible,
+.link-button:focus-visible,
+.odd-chip:focus-visible,
+.chip:focus-visible,
+.quick-amount:focus-visible,
+.stake-adjust:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
+}
+
+@media (max-width: 1280px) {
+  .dashboard-shell {
+    grid-template-columns: 240px minmax(0, 1fr) 300px;
+  }
+}
+
+@media (max-width: 1100px) {
+  .dashboard-shell {
+    grid-template-columns: 240px minmax(0, 1fr);
+    grid-template-areas:
+      "aside main"
+      "aside slip";
+  }
+
+  .shell-right {
+    align-self: stretch;
+  }
+}
+
+@media (max-width: 960px) {
+  .dashboard-shell {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "main"
+      "slip"
+      "aside";
+  }
+
+  .shell-left,
+  .shell-right {
+    flex-direction: column;
+  }
+
+  .shell-right {
+    gap: 1.25rem;
+  }
+}
+
+@media (max-width: 820px) {
+  .dashboard-header__top {
+    flex-wrap: wrap;
+  }
+
+  .header-widgets {
+    width: 100%;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .dashboard-search {
+    order: 3;
+    width: 100%;
+  }
+
+  .hero-banner {
+    padding: 2.2rem;
+  }
+
+  .hero-score {
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 680px) {
+  .dashboard-section__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .odds-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .live-now .live-strip {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .betslip__totals {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sports-accordion summary {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 540px) {
+  .hero-score {
+    grid-template-columns: minmax(0, 1fr);
+    text-align: center;
+  }
+
+  .hero-status {
+    order: -1;
+  }
+
+  .hero-markets {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .hero-banner {
+    padding: 1.8rem;
+  }
+
+  .dashboard-header__nav-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .live-ticker {
+    width: 100%;
+    white-space: normal;
+  }
+
+  .live-card__teams {
+    grid-template-columns: minmax(0, 1fr);
+    text-align: center;
+  }
+
+  .live-card__teams span {
+    display: none;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,778 @@
+:root {
+  --color-background: #05070f;
+  --color-surface: #0f172a;
+  --color-surface-light: rgba(15, 23, 42, 0.7);
+  --color-card: rgba(255, 255, 255, 0.06);
+  --color-highlight: #16f1b4;
+  --color-highlight-dark: #13c592;
+  --color-accent: #4b8bff;
+  --color-text: #e2e8f0;
+  --color-muted: #94a3b8;
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --shadow-soft: 0 20px 35px rgba(15, 23, 42, 0.45);
+  --shadow-card: 0 16px 40px rgba(0, 0, 0, 0.35);
+  --gradient-primary: linear-gradient(135deg, #2563eb, #0ea5e9);
+  --gradient-highlight: linear-gradient(120deg, #16f1b4, #3b82f6);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Archivo', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.14), transparent)
+      0 0/100% 300px no-repeat,
+    var(--color-background);
+  color: var(--color-text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+html.js [data-animate='fade-up'] {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.in-view {
+  opacity: 1 !important;
+  transform: translateY(0) !important;
+}
+
+.container {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+}
+
+.top-bar {
+  background: rgba(15, 23, 42, 0.9);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  position: relative;
+  z-index: 10;
+}
+
+.top-bar .container {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  letter-spacing: 0.03em;
+}
+
+.main-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(5, 7, 15, 0.85);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.main-nav .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.logo span {
+  color: var(--color-highlight);
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.nav-links a:hover {
+  color: var(--color-highlight);
+}
+
+.nav-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn {
+  padding: 0.7rem 1.6rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.btn.primary {
+  background: var(--gradient-primary);
+  color: #0b1120;
+  box-shadow: var(--shadow-soft);
+}
+
+.btn.primary:hover {
+  filter: brightness(1.1);
+  transform: translateY(-2px);
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.3);
+  color: var(--color-text);
+}
+
+.btn.ghost:hover {
+  border-color: var(--color-highlight);
+  color: var(--color-highlight);
+}
+
+.btn.full {
+  width: 100%;
+}
+
+main section {
+  padding: clamp(3rem, 6vw, 5.5rem) 0;
+}
+
+.hero {
+  background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.22), transparent 55%),
+    radial-gradient(circle at center left, rgba(20, 184, 166, 0.28), transparent 60%);
+}
+
+.hero .container {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  max-width: 520px;
+  color: var(--color-muted);
+  margin-bottom: 1.5rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: rgba(15, 23, 42, 0.7);
+  padding: 1.1rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.stat-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  display: block;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.hero-card {
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.25), rgba(14, 165, 233, 0.1));
+  padding: 2rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.live-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #f87171;
+  position: relative;
+  display: inline-block;
+}
+
+.live-dot::after {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 1px solid rgba(248, 113, 113, 0.6);
+}
+
+.hero-card__match {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.team-name {
+  font-weight: 600;
+}
+
+.team-score {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.match-info {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.hero-card__markets {
+  display: grid;
+  gap: 1rem;
+}
+
+.hero-card__markets div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}
+
+.hero-card__markets strong {
+  font-size: 1.1rem;
+  color: var(--color-highlight);
+}
+
+.features .container {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.feature-card {
+  background: var(--color-card);
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  backdrop-filter: blur(8px);
+}
+
+.feature-card h3 {
+  margin-bottom: 0.75rem;
+  font-size: 1.3rem;
+}
+
+.feature-card p {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-header h2 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.section-header p {
+  color: var(--color-muted);
+}
+
+.filters {
+  display: flex;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.filter-button {
+  border: none;
+  background: transparent;
+  color: var(--color-muted);
+  font-weight: 600;
+  padding: 0.45rem 1.2rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.filter-button.active {
+  background: var(--gradient-highlight);
+  color: #021219;
+  box-shadow: 0 10px 20px rgba(22, 241, 180, 0.25);
+}
+
+.odds-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.odds-card {
+  background: rgba(8, 13, 23, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  position: relative;
+  overflow: hidden;
+  min-height: 240px;
+}
+
+.odds-card.hidden {
+  display: none;
+}
+
+.odds-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(37, 99, 235, 0.18), transparent 55%);
+  pointer-events: none;
+}
+
+.odds-card header,
+.odds-card footer,
+.odds-card .match,
+.odds-card .stat-line {
+  position: relative;
+  z-index: 1;
+}
+
+.odds-card header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.match {
+  display: grid;
+  gap: 1rem;
+}
+
+.club {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.club strong {
+  font-size: 1.1rem;
+  color: var(--color-highlight);
+}
+
+.split-line {
+  height: 1px;
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.stat-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.odds-card footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.upcoming {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7), transparent 80%);
+}
+
+.schedule {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.schedule article {
+  background: rgba(8, 11, 20, 0.82);
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  backdrop-filter: blur(6px);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.schedule h3 {
+  font-size: 1.2rem;
+}
+
+.schedule p {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.schedule .tag {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+}
+
+.schedule .odds {
+  display: flex;
+  gap: 1rem;
+  color: var(--color-highlight);
+  font-weight: 600;
+}
+
+.promotions {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.08), rgba(59, 130, 246, 0.08));
+}
+
+.promo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.promo-card {
+  padding: 2.2rem;
+  border-radius: var(--radius-md);
+  background: rgba(2, 6, 23, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.promo-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(145deg, rgba(22, 241, 180, 0.18), transparent 60%);
+  pointer-events: none;
+}
+
+.promo-card h3 {
+  font-size: 1.4rem;
+}
+
+.promo-card p {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.promo-card .bonus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(22, 241, 180, 0.12);
+  color: var(--color-highlight);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.app-banner .container {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.25), rgba(30, 64, 175, 0.7));
+  border-radius: var(--radius-lg);
+  padding: clamp(2.5rem, 4vw, 4rem);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+  align-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: var(--shadow-card);
+  position: relative;
+  overflow: hidden;
+}
+
+.app-banner .container::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(22, 241, 180, 0.2), transparent 60%);
+  pointer-events: none;
+}
+
+.app-content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.app-content p {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.store-buttons {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.store {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 12px;
+  font-weight: 600;
+  border: 1px solid rgba(226, 232, 240, 0.3);
+  transition: transform 0.3s ease;
+}
+
+.store:hover {
+  transform: translateY(-2px);
+}
+
+.store.apple {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.store.android {
+  background: rgba(22, 241, 180, 0.12);
+  color: var(--color-highlight);
+}
+
+.app-phones {
+  position: relative;
+  height: 320px;
+}
+
+.phone {
+  position: absolute;
+  width: 160px;
+  height: 320px;
+  border-radius: 32px;
+  background: radial-gradient(circle at top, rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.8)),
+    #020617;
+  border: 6px solid rgba(226, 232, 240, 0.08);
+  top: 0;
+  right: 20%;
+  transform: rotate(-6deg);
+  box-shadow: var(--shadow-soft);
+}
+
+.phone.secondary {
+  right: 0;
+  top: 30px;
+  transform: rotate(8deg);
+}
+
+.footer {
+  background: #030712;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 3rem 0;
+}
+
+.footer .container {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) minmax(0, 0.8fr);
+  gap: 2.5rem;
+  align-items: flex-start;
+}
+
+.footer p {
+  color: var(--color-muted);
+  margin-top: 0.6rem;
+}
+
+.footer-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.footer-links h4 {
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.footer-links a {
+  display: block;
+  margin-bottom: 0.4rem;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.footer-links a:hover {
+  color: var(--color-highlight);
+}
+
+.footer-social {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: flex-end;
+}
+
+.footer-social .social-links {
+  display: flex;
+  gap: 0.8rem;
+}
+
+.footer-social a {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.footer-social a:hover {
+  color: var(--color-highlight);
+}
+
+@media (max-width: 1024px) {
+  .hero .container,
+  .app-banner .container {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card {
+    order: -1;
+  }
+
+  .odds-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .schedule {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .features .container,
+  .promo-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .footer .container {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-social {
+    justify-items: flex-start;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .odds-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .schedule {
+    grid-template-columns: 1fr;
+  }
+
+  .features .container,
+  .promo-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .app-phones {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .hero-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .filter-button {
+    flex: 1;
+    padding-inline: 0.5rem;
+  }
+
+  .store-buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1987,6 +1987,17 @@ body.dashboard-page .container {
   gap: 1.5rem;
 }
 
+.shell-left .panel {
+  background: linear-gradient(180deg, #101a3c, #070c1f);
+  border: 1px solid rgba(59, 130, 246, 0.22);
+  box-shadow: 0 24px 50px rgba(4, 10, 24, 0.45);
+  backdrop-filter: none;
+}
+
+.shell-left .panel::after {
+  display: none;
+}
+
 .shell-center {
   grid-area: main;
   display: flex;
@@ -2299,6 +2310,176 @@ body.dashboard-page .tag.boost {
 
 .dashboard-section__header .link-button {
   white-space: nowrap;
+}
+
+.rotating-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.rotating-banner__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.rotating-banner__copy p {
+  margin-top: 0.5rem;
+  color: rgba(226, 232, 240, 0.72);
+  max-width: 520px;
+}
+
+.rotating-banner__nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.rotating-banner__arrow {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.72);
+  color: #f8fafc;
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  cursor: pointer;
+  transition: background 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+}
+
+.rotating-banner__arrow:hover,
+.rotating-banner__arrow:focus-visible {
+  background: rgba(59, 130, 246, 0.24);
+  border-color: rgba(59, 130, 246, 0.5);
+  transform: translateY(-1px);
+}
+
+.rotating-banner__arrow:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.65);
+  outline-offset: 2px;
+}
+
+.rotating-banner__viewport {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  min-height: clamp(220px, 32vw, 320px);
+  background: #030712;
+}
+
+.carousel__slide {
+  position: absolute;
+  inset: 0;
+  padding: clamp(1.8rem, 4.5vw, 2.9rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.8rem;
+  color: #f8fafc;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(1.01);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.carousel__slide.is-active {
+  opacity: 1;
+  pointer-events: auto;
+  transform: scale(1);
+}
+
+.carousel__slide img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.02);
+  transition: transform 0.7s ease;
+  z-index: 0;
+  filter: saturate(1.1);
+}
+
+.carousel__slide.is-active img {
+  transform: scale(1.08);
+}
+
+.carousel__slide::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(2, 6, 23, 0.9) 15%, rgba(2, 6, 23, 0.4) 60%, rgba(2, 6, 23, 0.75));
+  z-index: 1;
+}
+
+.carousel__content {
+  position: relative;
+  z-index: 2;
+  max-width: min(440px, 65%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.carousel__content h3 {
+  font-size: clamp(1.35rem, 3vw, 1.95rem);
+  line-height: 1.2;
+}
+
+.carousel__content p {
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.carousel__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(22, 241, 180, 0.22);
+  color: var(--color-highlight);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.carousel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.carousel__dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.65rem;
+}
+
+.carousel__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(148, 163, 184, 0.35);
+  cursor: pointer;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.carousel__dot.is-active,
+.carousel__dot[aria-current='true'] {
+  background: var(--color-highlight);
+  transform: scale(1.2);
+}
+
+.carousel__dot:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
 }
 
 .hero-banner {
@@ -2905,6 +3086,10 @@ body.dashboard-page .tag.boost {
   .shell-right {
     gap: 1.25rem;
   }
+
+  .rotating-banner__header {
+    align-items: flex-start;
+  }
 }
 
 @media (max-width: 820px) {
@@ -2931,6 +3116,16 @@ body.dashboard-page .tag.boost {
   .hero-score {
     gap: 1rem;
   }
+
+  .rotating-banner__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .rotating-banner__nav {
+    align-self: flex-end;
+  }
 }
 
 @media (max-width: 680px) {
@@ -2953,6 +3148,10 @@ body.dashboard-page .tag.boost {
 
   .sports-accordion summary {
     flex-wrap: wrap;
+  }
+
+  .carousel__content {
+    max-width: 100%;
   }
 }
 
@@ -2992,5 +3191,15 @@ body.dashboard-page .tag.boost {
 
   .live-card__teams span {
     display: none;
+  }
+
+  .rotating-banner__viewport {
+    min-height: 220px;
+  }
+
+  .rotating-banner__arrow {
+    width: 2.4rem;
+    height: 2.4rem;
+    font-size: 1.1rem;
   }
 }


### PR DESCRIPTION
## Summary
- criar página inicial com hero, mercados ao vivo, agenda de jogos e banners promocionais para casa de apostas
- aplicar identidade visual moderna com gradientes, cards e responsividade em CSS puro
- adicionar script leve para filtros por modalidade e animações progressivas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee355c6e8832283576ae7f15d46fb